### PR TITLE
fix cluster scoped resource only case

### DIFF
--- a/pkg/util/lockedresourcecontroller/locked-resource-manager.go
+++ b/pkg/util/lockedresourcecontroller/locked-resource-manager.go
@@ -193,6 +193,10 @@ func (lrm *LockedResourceManager) scanNamespaces() []string {
 			}
 		}
 	}
+	//in case no namesopace is added it means that all of the objects are cluster scoped, then we need to add an emptu string to activate the cache.
+	if len(lrm.GetResources())+len(lrm.GetPatches()) > 0 && len(namespaceSet.List()) == 0 {
+		return []string{""}
+	}
 	return namespaceSet.List()
 }
 


### PR DESCRIPTION
Signed-off-by: Raffaele Spazzoli <raffaele.spazzoli@gmail.com>
this fixes a situation in which the multinamespace cache is created on cluster-scoped only resourcing causing teh cache to malfunction.