### PR TITLE
Adding support for manifest lists in LockedResource templates

### DIFF
--- a/pkg/util/lockedresourcecontroller/lockedresource/locked-resource.go
+++ b/pkg/util/lockedresourcecontroller/lockedresource/locked-resource.go
@@ -75,15 +75,17 @@ func GetLockedResourcesFromTemplates(resources []apis.LockedResourceTemplate, pa
 			log.Error(err, "unable to retrieve template for", "resource", resource)
 			return []LockedResource{}, nil
 		}
-		obj, err := util.ProcessTemplate(params, template)
+		objs, err := util.ProcessTemplateArray(params, template)
 		if err != nil {
 			log.Error(err, "unable to process template for", "resource", resource, "params", params)
 			return []LockedResource{}, nil
 		}
-		lockedResources = append(lockedResources, LockedResource{
-			Unstructured:  *obj,
-			ExcludedPaths: resource.ExcludedPaths,
-		})
+		for _, obj := range objs {
+			lockedResources = append(lockedResources, LockedResource{
+				Unstructured:  obj,
+				ExcludedPaths: resource.ExcludedPaths,
+			})
+		}
 	}
 	return lockedResources, nil
 }


### PR DESCRIPTION
Adding support for a list of manifests within the templates for LockedResources.

I tested using the [Namespace Config Operator](https://github.com/redhat-cop/namespace-configuration-operator), I did two tests

##Test 1
A objectTemplate that consists of an array, generated by a go template range loop. This resulted in 4 namespaces being created, test1, test2, and test3
```
  templates:
  - objectTemplate: |
      {{range $k, $v := $.Labels}}
      {{if eq $v "devteam"}}
      - apiVersion: v1
        kind: Namespace
        metadata:
          name: {{$k}}
      {{end}}
      {{end}}
```
```
kind: Group
apiVersion: user.openshift.io/v1
metadata:
  name: AI_Team
  labels:
    type: devproject
    projectname: saleslearning
    test1: devteam
    test2: devteam
    test3: devteam
    test4: testteam
```

##Test 2
Made sure the changes still support a single object which resulted in the creation of 1 namespace test

```
apiVersion: redhatcop.redhat.io/v1alpha1
kind: GroupConfig
metadata:
  name: team-onboarding
spec:
  labelSelector:
    matchLabels:
      type: devproject    
  templates:
  - objectTemplate: |
      apiVersion: v1
      kind: Namespace
      metadata:
        name: test
```
```
kind: Group
apiVersion: user.openshift.io/v1
metadata:
  name: AI_Team
  labels:
    type: devproject
    projectname: saleslearning
```
