### PR TITLE
Fix Left Difference

### DIFF
--- a/pkg/util/lockedresourcecontroller/enforcing-reconciler.go
+++ b/pkg/util/lockedresourcecontroller/enforcing-reconciler.go
@@ -125,7 +125,7 @@ func getToBeDeletdResources(neededResources []lockedresource.LockedResource, mod
 		neededResourceSet.Add(apis.GetKeyLong(&lockerResource))
 	}
 	for _, lockerResource := range modifiedResources {
-		neededResourceSet.Add(apis.GetKeyLong(&lockerResource))
+		modifiedResourcesSet.Add(apis.GetKeyLong(&lockerResource))
 		modifiedResourceMap[apis.GetKeyLong(&lockerResource)] = lockerResource
 	}
 	toBeDeletedKeys := strset.Difference(modifiedResourcesSet, neededResourceSet).List()


### PR DESCRIPTION
This fixes an issue with the left difference of the changing resource set vs the existing resource set, this will also resolve the following issue,
https://github.com/redhat-cop/namespace-configuration-operator/issues/74

WIP: I've validated this deletes the left set, but I'm going to run through some tests to make sure there is no unattended side effect or regressions.