### PR TITLE
Fix the intersection equality issue between the patch members

### DIFF
--- a/pkg/util/lockedresourcecontroller/locked-resource-manager.go
+++ b/pkg/util/lockedresourcecontroller/locked-resource-manager.go
@@ -1,8 +1,8 @@
 package lockedresourcecontroller
 
 import (
+	"encoding/json"
 	"errors"
-	"reflect"
 
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/redhat-cop/operator-utils/pkg/util"
@@ -250,9 +250,9 @@ func (lrm *LockedResourceManager) IsSamePatches(patches []lockedpatch.LockedPatc
 	same = currentPatchSet.IsEqual(newPatchSet)
 	//we also need to check intersection to see if there are differnces in the pacth definition
 	for _, patchID := range strset.Intersection(currentPatchSet, newPatchSet).List() {
-		currentPatch := currentPatchMap[patchID]
-		newPatch := newPatchMap[patchID]
-		if !reflect.DeepEqual(currentPatch, newPatch) {
+		currentPatch, _ := json.Marshal(currentPatchMap[patchID])
+		newPatch, _ := json.Marshal(newPatchMap[patchID])
+		if string(currentPatch) != string(newPatch) {
 			same = false
 			break
 		}

--- a/pkg/util/lockedresourcecontroller/patch-reconciler.go
+++ b/pkg/util/lockedresourcecontroller/patch-reconciler.go
@@ -168,9 +168,7 @@ var predicateLog = logf.Log.WithName("predicate").WithName("ReferenceModifiedPre
 
 // Update implements default UpdateEvent filter for validating resource version change
 func (p *referenceModifiedPredicate) Update(e event.UpdateEvent) bool {
-	fmt.Printf("got here1\n")
 	if e.MetaNew.GetName() == p.ObjectReference.Name && e.MetaNew.GetNamespace() == p.ObjectReference.Namespace {
-		log.Info("got here2")
 		if compareObjectsWithoutIgnoredFields(p.Client, e.MetaNew, p.ObjectReference) {
 			return false
 		}
@@ -205,7 +203,6 @@ func compareObjectsWithoutIgnoredFields(client client.Client, changedObjSrc meta
 	changeObj.SetResourceVersion("")
 	patchObj.SetManagedFields(nil)
 	patchObj.SetResourceVersion("")
-
 	changeObjJSON, _ := json.Marshal(changeObj)
 	patchObjJSON, _ := json.Marshal(patchObj)
 

--- a/pkg/util/lockedresourcecontroller/patch-reconciler.go
+++ b/pkg/util/lockedresourcecontroller/patch-reconciler.go
@@ -193,18 +193,18 @@ func (p *referenceModifiedPredicate) Generic(e event.GenericEvent) bool {
 
 // we ignore the fields of resourceVersion and managedFields
 func compareObjectsWithoutIgnoredFields(changedObjSrc runtime.Object, originalObjSrc runtime.Object) bool {
-	changeObj := changedObjSrc.DeepCopyObject().(*unstructured.Unstructured)
+	changedObj := changedObjSrc.DeepCopyObject().(*unstructured.Unstructured)
 	originalObj := originalObjSrc.DeepCopyObject().(*unstructured.Unstructured)
 
-	changeObj.SetManagedFields(nil)
-	changeObj.SetResourceVersion("")
+	changedObj.SetManagedFields(nil)
+	changedObj.SetResourceVersion("")
 	originalObj.SetManagedFields(nil)
 	originalObj.SetResourceVersion("")
 
-	changeObjJSON, _ := json.Marshal(changeObj)
+	changedObjJSON, _ := json.Marshal(changedObj)
 	originalObjJSON, _ := json.Marshal(originalObj)
 
-	return (string(changeObjJSON) == string(originalObjJSON))
+	return (string(changedObjJSON) == string(originalObjJSON))
 }
 
 //Reconcile method

--- a/pkg/util/lockedresourcecontroller/patch-reconciler.go
+++ b/pkg/util/lockedresourcecontroller/patch-reconciler.go
@@ -166,7 +166,7 @@ var predicateLog = logf.Log.WithName("predicate").WithName("ReferenceModifiedPre
 // Update implements default UpdateEvent filter for validating resource version change
 func (p *referenceModifiedPredicate) Update(e event.UpdateEvent) bool {
 	if e.MetaNew.GetName() == p.ObjectReference.Name && e.MetaNew.GetNamespace() == p.ObjectReference.Namespace {
-		if compareObjectsWithoutIgnoredFields(e.MetaNew, e.MetaOld) {
+		if compareObjectsWithoutIgnoredFields(e.ObjectNew, e.ObjectOld) {
 			return false
 		}
 		return true
@@ -192,9 +192,9 @@ func (p *referenceModifiedPredicate) Generic(e event.GenericEvent) bool {
 }
 
 // we ignore the fields of resourceVersion and managedFields
-func compareObjectsWithoutIgnoredFields(changedObjSrc metav1.Object, originalObjSrc metav1.Object) bool {
-	changeObj := changedObjSrc
-	originalObj := originalObjSrc
+func compareObjectsWithoutIgnoredFields(changedObjSrc runtime.Object, originalObjSrc runtime.Object) bool {
+	changeObj := changedObjSrc.DeepCopyObject().(*unstructured.Unstructured)
+	originalObj := originalObjSrc.DeepCopyObject().(*unstructured.Unstructured)
 
 	changeObj.SetManagedFields(nil)
 	changeObj.SetResourceVersion("")


### PR DESCRIPTION
I tested this using the tests in the /test folder of this project.
This relates to this reported issue https://github.com/redhat-cop/resource-locker-operator/issues/37

The Manager was being reset within the operator because it believed there was a change between the template definition and the tracked object within the cluster. This error seems to be related to a DeepEqual() which returned false, when comparing the objects I found this,

```
{ID:patch1 SourceObjectRefs:[] TargetObjectRef:{Kind:ServiceAccount Namespace:resource-locker-test Name:test UID: APIVersion:v1 ResourceVersion: FieldPath:} PatchType:application/strategic-merge-patch+json PatchTemplate:metadata:
  annotations:
    hello: bye
 Template:{name:metadata:
  annotations:
    hello: bye
 Tree:0xc000642600 common:0xc0005f4140 leftDelim: rightDelim:}} 
 

 {ID:patch1 SourceObjectRefs:[] TargetObjectRef:{Kind:ServiceAccount Namespace:resource-locker-test Name:test UID: APIVersion:v1 ResourceVersion: FieldPath:} PatchType:application/strategic-merge-patch+json PatchTemplate:metadata:
  annotations:
    hello: bye
 Template:{name:metadata:
  annotations:
    hello: bye
 Tree:0xc009a98a00 common:0xc001e1fcc0 leftDelim: rightDelim:}}
```

It appears the differences are all within the definition of the structs stack within memory, instead of comparing the signatures of the properties and values within the two structs. When marshalling this as JSON and comparing the string literals off that signature this operator works as expected.

A few questions I need before removing the WIP label:
1. What was the original intent of this code block? I'm not quire sure why it exists @raffaelespazzoli 
2. Is there a good reason that deep equal is failing on this compare, and is there a fundamental issue with comparing the json signatures vs in-memory.


EDIT:
I also made it so that when a tracked resource changes it no longer triggers a reconcile because of a change with `managedFields` or `resourceVersion`. This is done in a function titled `compareObjectsWithoutIgnoredFields` and is used in the Update() function for the predicate of the tracked resources within the operator.

@raffaelespazzoli I would like you to pull this down and test within your use case since I'm not 100%  sure I completely recreated that scenario.