### PR TITLE
Avoid panics in manageError when inspecting a nil instance

### DIFF
--- a/pkg/util/lockedresourcecontroller/resource-reconciler.go
+++ b/pkg/util/lockedresourcecontroller/resource-reconciler.go
@@ -230,7 +230,13 @@ func (lor *LockedResourceReconciler) manageError(instance *unstructured.Unstruct
 		Message:            err.Error(),
 		Reason:             apis.ReconcileErrorReason,
 		Status:             metav1.ConditionTrue,
-		ObservedGeneration: instance.GetGeneration(),
+		ObservedGeneration: func() int64 {
+			if instance != nil {
+				return instance.GetGeneration()
+			} else {
+				return 0
+			}
+		}(),
 	}
 	lor.setStatus(apis.AddOrReplaceCondition(condition, lor.GetStatus()))
 	return reconcile.Result{}, err


### PR DESCRIPTION
First of all I wanted to thank you for the awesome project, we are currently using in it a couple of our operators (https://github.com/3scale-ops/marin3r and https://github.com/3scale-ops/saas-operator). 

We have detected some panics in the `manageError` function that happen whenever errors occur in API calls that result in the call not returning a result. In these cases, calling `instance.GetGeneration` triggers a panic as `instance` is nil. In our case we have detected this primarily in our test suite, for example when the context is canceled before the API call is completed (which happens a lot in testing). I'm unsure if there are other error types that cause the same behavior, so my approach to fixing this was just making sure that `instance` actually holds a value before inspecting it. I don't know the code base that well, so maybe there is a better approach to fixing this.