### PR TITLE
Fix reconcile of deleted resources in namespaced mode

### DIFF
--- a/pkg/util/lockedresourcecontroller/resource-reconciler.go
+++ b/pkg/util/lockedresourcecontroller/resource-reconciler.go
@@ -211,7 +211,10 @@ func (p *resourceModifiedPredicate) Delete(e event.DeleteEvent) bool {
 			err := p.lrr.GetClient().Get(context.TODO(), types.NamespacedName{Name: e.Object.GetNamespace()}, &namespace)
 			if err != nil {
 				p.lrr.log.Error(err, "unable to retrieve ", "namespace", "e.Meta.GetNamespace()")
-				return false
+				// If the request failed return "true" as the k8s API will deny any create/update operation in a
+				// Namespace that's marked for termination. Returning false here causes resources not being reconciled
+				// in namespaced installations (Namespace requires a client with cluster scoped permissions)
+				return true
 			}
 			if util.IsBeingDeleted(&namespace) {
 				return false


### PR DESCRIPTION
There is a bug when using the locked resources controller where deleted resources are never reconciled. This occurs because the predicate for deletion events has code that checks if the Namespace of the deleted resource is in the process of being terminated. This only works when the reconciler is used with cluster scoped permissions. The current code returns false if an error occurs trying to retrieve the Namespace, which leads to the resources never being reconciled again. This could be not only a permissions problem, but also a temporary unavailability of the API server.

The proposed solution is to return true, as a fallback, if the get operation of the Namespace resource fails so the resource is reconciled. This is not even a problem in the case the Namespace is actually being deleted, as the api server will refuse to perform any create/update if the Namespace is being terminated.
