### PR TITLE
Nil pointer dereference in LockedResourceManager v1.2.0

### DIFF
--- a/pkg/util/lockedresourcecontroller/locked-resource-manager.go
+++ b/pkg/util/lockedresourcecontroller/locked-resource-manager.go
@@ -73,7 +73,7 @@ func (lrm *LockedResourceManager) GetPatches() []lockedpatch.LockedPatch {
 
 // SetResources set the resources to be enforced. Can be called only when the LockedResourceManager is stopped.
 func (lrm *LockedResourceManager) SetResources(resources []lockedresource.LockedResource) error {
-	if lrm.stoppableManager.IsStarted() {
+	if lrm.stoppableManager != nil && lrm.stoppableManager.IsStarted() {
 		return errors.New("cannot set resources while enforcing is on")
 	}
 	err := lrm.validateLockedResources(resources)
@@ -87,7 +87,7 @@ func (lrm *LockedResourceManager) SetResources(resources []lockedresource.Locked
 
 // SetPatches set the patches to be enforced. Can be called only when the LockedResourceManager is stopped.
 func (lrm *LockedResourceManager) SetPatches(patches []lockedpatch.LockedPatch) error {
-	if lrm.stoppableManager.IsStarted() {
+	if lrm.stoppableManager != nil && lrm.stoppableManager.IsStarted() {
 		return errors.New("cannot set resources while enforcing is on")
 	}
 	// verifyPatchID Uniqueness


### PR DESCRIPTION
Hi all,

Thanks for this library.  Nice to see an attempt to promote some patterns for operators.

Version 1.2.0 in this commit: https://github.com/redhat-cop/operator-utils/commit/99bdc3068fab3e2bbd8c4c541f20e2c622b1332d changed LockedResourceManager.stoppableManager to a pointer.  This has broken controller startup for us with a nil pointer dereference.

r.UpdateLockedResources() when called for the first time, ends up calling lockedResourceManager.Restart().
lockedResourceManager.Restart() calls lrm.IsStarted().
lrm.IsStarted() calls lrm.stoppableManager.IsStarted() but lrm.stoppableManager is nil resulting in the trace below:

```
Exception has occurred: panic
"runtime error: invalid memory address or nil pointer dereference"
Stack:
	 4  0x0000000001c4b3bd in github.com/redhat-cop/operator-utils/pkg/util/stoppablemanager.(*StoppableManager).IsStarted
	     at /home/itcalde/go/pkg/mod/github.com/redhat-cop/operator-utils@v1.2.0/pkg/util/stoppablemanager/stoppable-manager.go:62
	 5  0x0000000001c51c32 in github.com/redhat-cop/operator-utils/pkg/util/lockedresourcecontroller.(*LockedResourceManager).IsStarted
	     at /home/itcalde/go/pkg/mod/github.com/redhat-cop/operator-utils@v1.2.0/pkg/util/lockedresourcecontroller/locked-resource-manager.go:115
	 6  0x0000000001c53285 in github.com/redhat-cop/operator-utils/pkg/util/lockedresourcecontroller.(*LockedResourceManager).Restart
```

This patch adds some nil checks which resolve the issue, but maybe it is better for NewLockedResourceManager() to create a StoppableManager?