### PR TITLE
Propagate the context to the stoppable-managers for ordered shutdown

### DIFF
--- a/pkg/util/lockedresourcecontroller/enforcing-reconciler.go
+++ b/pkg/util/lockedresourcecontroller/enforcing-reconciler.go
@@ -113,7 +113,7 @@ func (er *EnforcingReconciler) UpdateLockedResourcesWithRestConfig(context conte
 			er.log.Error(err, "unable to delete unmanaged", "resources", leftDifference)
 			return err
 		}
-		err := lockedResourceManager.Restart(lockedResources, lockedPatches, false, config)
+		err := lockedResourceManager.Restart(context, lockedResources, lockedPatches, false, config)
 		if err != nil {
 			er.log.Error(err, "unable to restart", "manager", lockedResourceManager)
 			return err

--- a/pkg/util/lockedresourcecontroller/locked-resource-manager.go
+++ b/pkg/util/lockedresourcecontroller/locked-resource-manager.go
@@ -119,7 +119,7 @@ func (lrm *LockedResourceManager) IsStarted() bool {
 }
 
 // Start starts the LockedResourceManager
-func (lrm *LockedResourceManager) Start(config *rest.Config) error {
+func (lrm *LockedResourceManager) Start(ctx context.Context, config *rest.Config) error {
 	if lrm.stoppableManager != nil && lrm.stoppableManager.IsStarted() {
 		return nil
 	}
@@ -165,7 +165,7 @@ func (lrm *LockedResourceManager) Start(config *rest.Config) error {
 	}
 	lrm.patchReconcilers = patchReconcilers
 
-	lrm.stoppableManager.Start()
+	lrm.stoppableManager.Start(ctx)
 	return nil
 }
 
@@ -210,7 +210,8 @@ func (lrm *LockedResourceManager) scanNamespaces() []string {
 
 // Restart restarts the manager with a different set of resources
 // if deleteResources is set, resources that were enforced are deleted.
-func (lrm *LockedResourceManager) Restart(resources []lockedresource.LockedResource, patches []lockedpatch.LockedPatch, deleteResources bool, config *rest.Config) error {
+func (lrm *LockedResourceManager) Restart(ctx context.Context, resources []lockedresource.LockedResource,
+	patches []lockedpatch.LockedPatch, deleteResources bool, config *rest.Config) error {
 	if lrm.IsStarted() {
 		err := lrm.Stop(deleteResources)
 		if err != nil {
@@ -228,7 +229,7 @@ func (lrm *LockedResourceManager) Restart(resources []lockedresource.LockedResou
 		lrm.log.Error(err, "unable to set", "patches", patches)
 		return err
 	}
-	return lrm.Start(config)
+	return lrm.Start(ctx, config)
 }
 
 // IsSameResources checks whether the currently enforced resources are the same as the ones passed as parameters

--- a/pkg/util/stoppablemanager/stoppable-manager.go
+++ b/pkg/util/stoppablemanager/stoppable-manager.go
@@ -30,12 +30,12 @@ func (sm *StoppableManager) Stop() {
 }
 
 //Start starts the manager. Restarting a starated manager is a noop that will be logged.
-func (sm *StoppableManager) Start() {
+func (sm *StoppableManager) Start(parentCtx context.Context) {
 	if sm.started {
 		log.Error(errors.New("invalid argument"), "start called on a started channel")
 		return
 	}
-	ctx, cancel := context.WithCancel(context.TODO())
+	ctx, cancel := context.WithCancel(parentCtx)
 	sm.cancelFunction = cancel
 	go func() {
 		err := sm.Manager.Start(ctx)


### PR DESCRIPTION
This PR adds propagation of the parent context to the stoppable managers so they stop when the parent context is cancelled. I run into problems with this while running tests with the envtest framework using the 1.22 version of the k8s api server. It seems that the api server blocks until all running controllers are shutdown and this was causing the tests to fail during the api server shutdown phase.